### PR TITLE
Add vimeo embed plugin

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,8 +2,11 @@ const navigation = require('@11ty/eleventy-navigation')
 const dates = require('./utilities/filters/dates')
 const helpers = require('./utilities/filters/helpers')
 const path = require('path')
+const embedVimeo = require("eleventy-plugin-vimeo-embed");
 
 module.exports = config => {
+    // vimeo plugin
+    config.addPlugin(embedVimeo)
 
     // navigation plugin
     config.addPlugin(navigation)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.11.1",
     "@11ty/eleventy-navigation": "^0.1.6",
+    "eleventy-plugin-vimeo-embed": "^1.3.0",
     "gorko": "^0.2.3",
     "html-minifier": "^4.0.0",
     "laravel-mix": "^6.0.11",

--- a/site/includes/layouts/home.njk
+++ b/site/includes/layouts/home.njk
@@ -1,7 +1,9 @@
 ---
 layout: base
 ---
-
+<p>
+https://vimeo.com/165761113
+</p>
 <main id="main" class="main inner box-flex pt-1000 pb-1000" tabindex="-1">
     <header class="hero page-header laptop:box-flex">
         <div class="laptop:width-half">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,6 +3153,11 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz#b4f81c930b388f962b7eba20d0483299aaa40913"
   integrity sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==
 
+eleventy-plugin-vimeo-embed@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eleventy-plugin-vimeo-embed/-/eleventy-plugin-vimeo-embed-1.3.0.tgz#9f050ee649740ae499f38c43ac0241416a746eeb"
+  integrity sha512-0b+A9lp9pprD+Q9qZ8nkctWA0GPiZIBLNeuQe+39gg52BTSscZaenl2V88RZmyTWBaDv/HBgS8QxMG/+WHwJMQ==
+
 elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"


### PR DESCRIPTION
## Motivation

To display an imbedded video on backstage open mic.

## Approach

Preview [here](https://deploy-preview-5--backstage-openmic.netlify.app/).

It just required a [`eleventy-plugin-vimeo-embed`](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed) install and added to the eleventy config.

![Screen Shot 2021-05-15 at 5 48 38 AM](https://user-images.githubusercontent.com/29791650/118356014-39abe380-b541-11eb-862e-f960a989c9fa.png)
